### PR TITLE
Follow-up #400: iWaitForAjaxToFinish() broken for D7

### DIFF
--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -126,11 +126,16 @@ class MinkContext extends MinkExtension implements TranslatableContext {
       function isAjaxing(instance) {
         return instance && instance.ajaxing === true;
       }
+      var d7_not_ajaxing = true;
+      if (typeof Drupal !== 'undefined' && typeof Drupal.ajax !== 'undefined' && typeof Drupal.ajax.instances === 'undefined') {
+        for(var i in Drupal.ajax) { if (isAjaxing(Drupal.ajax[i])) { d7_not_ajaxing = false; } }
+      }
+      var d8_not_ajaxing = (typeof Drupal === 'undefined' || typeof Drupal.ajax === 'undefined' || typeof Drupal.ajax.instances === 'undefined' || !Drupal.ajax.instances.some(isAjaxing))
       return (
         // Assert no AJAX request is running (via jQuery or Drupal) and no
         // animation is running.
         (typeof jQuery === 'undefined' || (jQuery.active === 0 && jQuery(':animated').length === 0)) &&
-        (typeof Drupal === 'undefined' || typeof Drupal.ajax === 'undefined' || !Drupal.ajax.instances.some(isAjaxing))
+        d7_not_ajaxing && d8_not_ajaxing
       );
     }());
 JS;


### PR DESCRIPTION
The issue fixed in #400 breaks the D7 check.
Only thing missing is a check if ` Drupal.ajax.instances` actually exists - which is only the case in D8.
Without the check we get an error like "Call method some on undefined".
While checking the code in D7 I realized we've instances with the ajaxing flag there as well - we just need to access the instances in a different way.
I've tried to do that in this change too.

So far only tested with a D7 installation.